### PR TITLE
remove unused tsconfig values

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,7 @@
   "exclude": [
     "typings/browser.d.ts",
     "typings/browser",
-    "node_modules",
-    "config", 
-    "dev_server.js"
+    "node_modules"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
tsconfig.json file has the following "exclude" key.
Here,  config and dev_server.js values have no affect on the tsc because (1) there is no "config" folder in our project (2) ".js" files are already excluded:
OLD: 
 "exclude": [
    "typings/browser.d.ts",
    "typings/browser",
    "node_modules",
    "config", 
    "dev_server.js"
  ]
NEW:
 "exclude": [
    "typings/browser.d.ts",
    "typings/browser",
    "node_modules"
  ],
