### PR TITLE
Initialize 'schemas' collection in mongo upon start

### DIFF
--- a/mongo/Dockerfile
+++ b/mongo/Dockerfile
@@ -6,6 +6,7 @@ ARG ADMIN_PASS
 COPY mongo-setup.sh /
 COPY db.js /
 COPY header.data.json /
+COPY EditorialPanelFiftyFiftyFullWidth.json EditorialPanelSkinnyBanner.json /
 RUN chmod 755 /mongo-setup.sh
 RUN echo ${USERADMIN_PASS}
 RUN USERADMIN_PASS=${USERADMIN_PASS} ADMIN_PASS=${ADMIN_PASS} /mongo-setup.sh

--- a/mongo/EditorialPanelFiftyFiftyFullWidth.json
+++ b/mongo/EditorialPanelFiftyFiftyFullWidth.json
@@ -1,0 +1,130 @@
+{
+  "title": "Editorial Panel: 50/50 or Full Width",
+  "description": "An editorial module, either split down the middle (50/50) or full-width, based on the Component Type chosen.",
+  "type": "object",
+  "required": [
+    "component_type", "image_path"
+  ],
+  "properties": {
+    "component_type": {
+      "type": "string",
+      "title": "Component Type",
+      "enum": [
+        "EditorialPanelFiftyFifty", "EditorialPanelFullWidth"
+      ],
+      "uniqueItems": true,
+      "default": "EditorialPanelFiftyFifty"
+    },
+    "headline": {
+      "type": "string",
+      "title": "Headline"
+    },
+    "headline_color": {
+      "type": "string",
+      "title": "Headline Color",
+      "default": "#4a7cff"
+    },
+    "headline_font": {
+      "type": "string",
+      "title": "Headline Font",
+      "default": "acumin"
+    },
+    "image_path": {
+      "type": "string",
+      "title": "Image Path"
+    },
+    "image_alt_text": {
+      "type": "string",
+      "title": "Image Alt Text"
+    },
+    "body_copy1": {
+      "type": "string",
+      "title": "Body Copy 1"
+    },
+    "body_copy2": {
+      "type": "string",
+      "title": "Body Copy 2"
+    },
+    "cta1_url": {
+      "type": "string",
+      "title": "Click-to-Action (CTA) 1 URL"
+    },
+    "cta1_mobile_url": {
+      "type": "string",
+      "title": "CTA 1 Mobile URL"
+    },
+    "cta1_label": {
+      "type": "string",
+      "title": "CTA 1 Label"
+    },
+    "cta1_target": {
+      "type": "string",
+      "title": "CTA 1 Target",
+      "default": "_self"
+    },
+    "cta2_url": {
+      "type": "string",
+      "title": "Click-to-Action (CTA) 2 URL"
+    },
+    "cta2_mobile_url": {
+      "type": "string",
+      "title": "CTA 2 Mobile URL"
+    },
+    "cta2_label": {
+      "type": "string",
+      "title": "CTA 2 Label"
+    },
+    "cta2_target": {
+      "type": "string",
+      "title": "CTA 2 Target",
+      "default": "_self"
+    },
+    "default_cta": {
+      "type": "string",
+      "title": "Default CTA",
+      "enum": [
+        "cta1", "cta2"
+      ],
+      "uniqueItems": true,
+      "default": "cta1"
+    },
+    "subhead1": {
+      "type": "string",
+      "title": "Subheading 1"
+    },
+    "subhead2": {
+      "type": "string",
+      "title": "Subheading 2"
+    },
+    "subhead3": {
+      "type": "string",
+      "title": "Subheading 3"
+    },
+    "live_copy_position": {
+      "type": "string",
+      "title": "Live Copy Position",
+      "enum": [
+        "left", "right"
+      ],
+      "uniqueItems": true,
+      "default": "right"
+    },
+    "live_copy_font_color": {
+      "type": "string",
+      "title": "Live Copy Font Color",
+      "enum": [
+        "white", "black"
+      ],
+      "uniqueItems": true,
+      "default": "black"
+    },
+    "footnote_marker": {
+      "type": "string",
+      "title": "Footnote Marker"
+    },
+    "disclaimer_text": {
+      "type": "string",
+      "title": "Disclaimer Text"
+    }
+  }
+}

--- a/mongo/EditorialPanelSkinnyBanner.json
+++ b/mongo/EditorialPanelSkinnyBanner.json
@@ -1,0 +1,92 @@
+{
+  "title": "Editorial Panel: Skinny Banner",
+  "description": "A slim editorial module",
+  "type": "object",
+  "required": [
+    "image_path"
+  ],
+  "properties": {
+    "background_color": {
+      "type": "string",
+      "title": "Background Color",
+      "default": "#9dd2e4"
+    },
+    "headline": {
+      "type": "string",
+      "title": "Headline"
+    },
+    "headline_color": {
+      "type": "string",
+      "title": "Headline Color",
+      "default": "#000000"
+    },
+    "headline_font": {
+      "type": "string",
+      "title": "Headline Font",
+      "default": "acumin"
+    },
+    "image_path": {
+      "type": "string",
+      "title": "Image Path"
+    },
+    "image_alt_text": {
+      "type": "string",
+      "title": "Image Alt Text"
+    },
+    "body_copy1": {
+      "type": "string",
+      "title": "Body Copy"
+    },
+    "cta1_url": {
+      "type": "string",
+      "title": "Click-to-Action (CTA) 1 URL"
+    },
+    "cta1_mobile_url": {
+      "type": "string",
+      "title": "CTA 1 Mobile URL"
+    },
+    "cta1_label": {
+      "type": "string",
+      "title": "CTA 1 Label"
+    },
+    "cta1_target": {
+      "type": "string",
+      "title": "CTA 1 Target",
+      "default": "_self"
+    },
+    "cta2_url": {
+      "type": "string",
+      "title": "Click-to-Action (CTA) 2 URL"
+    },
+    "cta2_mobile_url": {
+      "type": "string",
+      "title": "CTA 2 Mobile URL"
+    },
+    "cta2_label": {
+      "type": "string",
+      "title": "CTA 2 Label"
+    },
+    "cta2_target": {
+      "type": "string",
+      "title": "CTA 2 Target",
+      "default": "_self"
+    },
+    "default_cta": {
+      "type": "string",
+      "title": "Default CTA",
+      "enum": [
+        "cta1", "cta2"
+      ],
+      "uniqueItems": true,
+      "default": "cta1"
+    },
+    "footnote_marker": {
+      "type": "string",
+      "title": "Footnote Marker"
+    },
+    "disclaimer_text": {
+      "type": "string",
+      "title": "Disclaimer Text"
+    }
+  }
+}

--- a/mongo/mongo-setup.sh
+++ b/mongo/mongo-setup.sh
@@ -14,6 +14,8 @@ done
 mongo admin --port 27017 -u userAdmin -p ${USERADMIN_PASS} --authenticationDatabase "admin" --eval 'db.createUser({"user":"admin", "pwd":"'${ADMIN_PASS}'", "roles": [ "dbAdminAnyDatabase", "readWriteAnyDatabase" ] })'
 mongo watts --port 27017 -u admin -p ${ADMIN_PASS} --authenticationDatabase "admin" db.js
 
-mongoimport -u admin -p ${ADMIN_PASS} --authenticationDatabase "admin" --db watts --collection headers --jsonArray --drop --file ./header.data.json
+mongoimport -u admin -p ${ADMIN_PASS} --authenticationDatabase "admin" --db watts --collection headers --jsonArray --file ./header.data.json
+mongoimport -u admin -p ${ADMIN_PASS} --authenticationDatabase "admin" --db watts --collection schemas --file ./EditorialPanelFiftyFiftyFullWidth.json
+mongoimport -u admin -p ${ADMIN_PASS} --authenticationDatabase "admin" --db watts --collection schemas --file ./EditorialPanelSkinnyBanner.json
 
 mongod --shutdown --dbpath=/containerdb


### PR DESCRIPTION
.json files must be copied from ./plugins/contentedit/json/ into
./mongo/ in order for mongo-setup.sh to create schemas for them.

 Changes to be committed:
	modified:   Dockerfile
	new file:   EditorialPanelFiftyFiftyFullWidth.json
	new file:   EditorialPanelSkinnyBanner.json
	modified:   mongo-setup.sh